### PR TITLE
asdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9:9.1.0-1750
 COPY requirements.txt .
 
 RUN dnf install -y \
-    curl git \
+    git-2.31.1-2.el9.2.x86_64 \
     openssh-clients-8.7p1-24.el9_1.x86_64 \
     unzip-6.0-56.el9.x86_64 \
     wget-1.21.1-7.el9.x86_64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi9:9.1.0-1750
 COPY requirements.txt .
 
 RUN dnf install -y \
+    curl git \
     openssh-clients-8.7p1-24.el9_1.x86_64 \
     unzip-6.0-56.el9.x86_64 \
     wget-1.21.1-7.el9.x86_64 \
@@ -12,6 +13,9 @@ RUN dnf install -y \
     dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
     dnf install -y terraform-1.3.7-1.x86_64 && \
     dnf clean all -y && \
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 && \
+    echo ". $HOME/.asdf/asdf.sh" >> ~/.bashrc && \
+    echo ". $HOME/.asdf/completions/asdf.bash" >> ~/.bashrc && \
     wget https://github.com/gruntwork-io/terragrunt/releases/download/v0.43.0/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
     chmod +x /usr/local/bin/terragrunt && \
     wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O awscliv2.zip && \


### PR DESCRIPTION
asdf will be used to install aws cli. Currently, the latest version is picked up every time the container image is built. This can cause an unreproducible build.